### PR TITLE
Bugfix/task symbols encoding

### DIFF
--- a/src/test/java/TaskSearchTest.java
+++ b/src/test/java/TaskSearchTest.java
@@ -51,8 +51,8 @@ public class TaskSearchTest {
         Response searchResponse = searcher.searchAndDisplay("borrow");
         
         String expectedMessage = "Here are the matching tasks in your list:\n"
-                                         + "[T] [✘] borrow book\n"
-                                         + "[T] [✘] borrow umbrella\n";
+                                         + "[T] [\u2718] borrow book\n"
+                                         + "[T] [\u2718] borrow umbrella\n";
         assertEquals(expectedMessage, searchResponse.getMessage());
     }
 }


### PR DESCRIPTION
Replace symbols in task search tests with utf encodings. Builds on windows were failing.